### PR TITLE
Make deps as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 all:
+	./rebar -v get-deps
 	./rebar -v compile
 
 clean:
+	./rebar -v delete-deps
 	./rebar -v clean
 
 eunit:


### PR DESCRIPTION
sha3 needed to make hex dependencies from the referenced git repo.

Otherwise, was getting this symptom:

```
~projects/sha3 git:(master)  make                                                                                      [1.58] 16:12:15
./rebar -v compile
WARN:  Expected /Users/tpowell/projects/sha3/deps/hex to be an app dir (containing ebin/*.app), but no .app found.
==> sha3 (compile)
WARN:  Expected /Users/tpowell/projects/sha3/deps/hex to be an app dir (containing ebin/*.app), but no .app found.
Dependency not available: hex-.* ({git,"git://github.com/b/hex","HEAD"})
ERROR: compile failed while processing /Users/tpowell/projects/sha3: rebar_abort
```
